### PR TITLE
Feature/naming and configdict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,17 @@
 
 What?
-================================================================
+===============================================================================
 
-A simple tool for loading ``YAML`` and ``JSON`` configuration/settings using 
+A simple tool for loading ``YAML`` and ``JSON`` configuration/settings using
 ``pydantic2``.
 
-There is also a version for ``pydantic1``, see ``release/v1``. Major 
-versions of this package will match the major version of the respective 
+There is also a version for ``pydantic1``, see ``release/v1``. Major
+versions of this package will match the major version of the respective
 ``pydantic`` release.
 
 
 Why?
-================================================================
+===============================================================================
 
 This project can be helpful for projects that have large configuration files,
 nested configuration files, or for those of us who don't like writing large ``.env``
@@ -46,8 +46,8 @@ There are two classes worth knowing about:
 - ``CreateYamlSettings`` -- The pydantic ``PydanticBaseSettingsSource`` that
   will analyze your class for the following class variables:
 
-  1. Files to be used -- under ``__env_yaml_settings_files__``.
-  2. The reload settings -- under ``__env_yaml_settings_reload__``.
+  1. Files to be used -- under ``__env_yaml_files__``.
+  2. The reload settings -- under ``__env_yaml_reload__``.
 
   This does not have to be used at all, but can be helpful if you don't want to
   use ``BaseYamlSettings`` for any reason.
@@ -63,15 +63,15 @@ The shortest possible example is as follows:
    from yaml_settings_pydantic import BaseYamlSettings
 
    class MySettings(BaseYamlSettings):
-      __env_yaml_settings_files__ = ["settings.yaml"]
+      __env_yaml_files__ = "settings.yaml"
 
       setttingOne: str
       settingTwo: str
       ...
-      
+
    ...
 
 
 Also see the example in ``./tests/examples/__init__.py``. It is gaurenteed to
-work as its contents are tested and contain information on how to write nested
+work as its contents are tested. It contains information on how to write nested
 configurations.

--- a/README.rst
+++ b/README.rst
@@ -39,22 +39,38 @@ Install using ``pip``:
 Examples
 ===============================================================================
 
-It might be worth reading pydantics documentation about additional sources: https://docs.pydantic.dev/latest/usage/pydantic_settings/
+Additional information
+-------------------------------------------------------------------------------
 
-There are two classes worth knowing about:
+First, it is worth reading the ``pydantic_settings`` docs about additional sources: https://docs.pydantic.dev/latest/usage/pydantic_settings/
 
+Additionally see the example in ``./tests/examples/__init__.py``. It is gaurenteed to
+work as its contents are tested. It contains information on how to write nested
+configurations.
+
+
+Tools
+-------------------------------------------------------------------------------
+
+There are three classes worth knowing about:
+
+- ``YamlSettingsConfigDict`` -- ``pydantic_settings.SetttingsConfigDict``
+  extended to include the fields used by ``CreateYamlSettings``.
 - ``CreateYamlSettings`` -- The pydantic ``PydanticBaseSettingsSource`` that
   will analyze your class for the following class variables:
 
-  1. Files to be used -- under ``__env_yaml_files__``.
-  2. The reload settings -- under ``__env_yaml_reload__``.
+  1. Files to be used -- under ``__env_yaml_files__`` or ``model_config.yaml_files``.
+  2. The reload settings -- under ``__env_yaml_reload__`` or ``model_config.yaml_reload``.
 
-  This does not have to be used at all, but can be helpful if you don't want to
-  use ``BaseYamlSettings`` for any reason.
+  ``CreateYamlSettings`` does not have to be used at all, but can be helpful if
+  you don't want to use ``BaseYamlSettings`` for any reason.
 
 - ``BaseYamlSettings`` -- Use this directly as done in the example below. This
   is 'the easy way'.
 
+
+Minimal Examples
+-------------------------------------------------------------------------------
 
 The shortest possible example is as follows:
 
@@ -72,6 +88,31 @@ The shortest possible example is as follows:
    ...
 
 
-Also see the example in ``./tests/examples/__init__.py``. It is gaurenteed to
-work as its contents are tested. It contains information on how to write nested
-configurations.
+Note that the above example can also be written like
+
+
+.. code:: python
+
+   from yaml_settings_pydantic import BaseYamlSettings, YamlSettingsConfigDict
+
+   class MySettings(BaseYamlSettings):
+      model_config = YamlSettingsConfigDict(yaml_files="settings.yaml")
+
+      setttingOne: str
+      settingTwo: str
+      ...
+
+   ...
+
+
+which is more like pydantic v2. The 'dunder' specifications will take priority
+over their equivalent `model_config` specifications. These map as follows:
+
+.. code:: text
+
+  +-----------------------+------------------+
+  | dunder                | model_config     |
+  +-----------------------+------------------+
+  | __env_yaml_files__    | yaml_files       |
+  | __env_yaml_reload__   | yaml_reload      |
+  +-----------------------+------------------+

--- a/tests/examples/__init__.py
+++ b/tests/examples/__init__.py
@@ -17,19 +17,16 @@ class MySettings(BaseYamlSettings):
     model_config = SettingsConfigDict(
         env_prefix="MY_SETTINGS_",
         env_nested_delimiter="__",
-        # env_file="example.env",
     )
 
     # Dunders implement which files will be used and how.
     # This one specifies the files to be used. Multiple files can be used.
     # Make sure that this is a tuple.
-    __env_yaml_settings_files__ = (
-        path.realpath(path.join(path.dirname(__file__), "example.yaml")),
-    )
+    __yaml_files__ = (path.realpath(path.join(path.dirname(__file__), "example.yaml")),)
 
     # Use reload to determine if CreateYamlSettings will load and parse the
     # provided files every time it is called.
-    __env_yaml_settings_reload__ = True
+    __yaml_reload__ = True
 
     # Nested configuration example.
     class MyDataBaseSettings(BaseModel):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,12 @@
+from typing import Set, Tuple
+
 import pytest
 import yaml
-from yaml_settings_pydantic import BaseYamlSettings, CreateYamlSettings
+from yaml_settings_pydantic import (
+    BaseYamlSettings,
+    CreateYamlSettings,
+    YamlSettingsConfigDict,
+)
 
 
 class TestCreateYamlSettings:
@@ -47,3 +53,31 @@ class TestCreateYamlSettings:
             yaml.dump({}, file)
 
         yaml_settings()
+
+    def test_dunders_have_priority(self) -> None:
+        init_files: Set[str] = {"foo-bar.yaml"}
+        model_config = YamlSettingsConfigDict(
+            yaml_reload=(init_reload := True),
+            yaml_files=init_files,
+        )
+
+        Settings = type(
+            "Settings",
+            (BaseYamlSettings,),
+            dict(model_config=model_config),
+        )
+        yaml_settings = CreateYamlSettings(Settings)
+
+        assert yaml_settings.files == init_files
+        assert yaml_settings.reload == init_reload
+
+        final_files: Set[str] = {"spam-eggs.yaml"}
+        OverwriteSettings = type(
+            "OverwriteSettings",
+            (Settings,),
+            dict(__env_yaml_settings_files__=final_files),
+        )
+        yaml_settings = CreateYamlSettings(OverwriteSettings)
+
+        assert yaml_settings.files == final_files
+        assert yaml_settings.reload == init_reload

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,8 +21,8 @@ class TestCreateYamlSettings:
                 "Settings",
                 (BaseYamlSettings,),
                 dict(
-                    __env_yaml_reload__=reload or False,
-                    __env_yaml_files__=files or set(fileDummies),
+                    __yaml_reload__=reload or False,
+                    __yaml_files__=files or set(fileDummies),
                 ),
             )
 
@@ -32,7 +32,7 @@ class TestCreateYamlSettings:
         assert not yaml_settings.reload
 
         # Malform a file.
-        bad = Settings.__env_yaml_files__.pop()
+        bad = Settings.__yaml_files__.pop()
         with open(bad, "w") as file:
             yaml.dump([], file)
 
@@ -75,7 +75,7 @@ class TestCreateYamlSettings:
         OverwriteSettings = type(
             "OverwriteSettings",
             (Settings,),
-            dict(__env_yaml_files__=final_files),
+            dict(__yaml_files__=final_files),
         )
         yaml_settings = CreateYamlSettings(OverwriteSettings)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,8 +21,8 @@ class TestCreateYamlSettings:
                 "Settings",
                 (BaseYamlSettings,),
                 dict(
-                    __env_yaml_settings_reload__=reload or False,
-                    __env_yaml_settings_files__=files or set(fileDummies),
+                    __env_yaml_reload__=reload or False,
+                    __env_yaml_files__=files or set(fileDummies),
                 ),
             )
 
@@ -32,7 +32,7 @@ class TestCreateYamlSettings:
         assert not yaml_settings.reload
 
         # Malform a file.
-        bad = Settings.__env_yaml_settings_files__.pop()
+        bad = Settings.__env_yaml_files__.pop()
         with open(bad, "w") as file:
             yaml.dump([], file)
 
@@ -75,7 +75,7 @@ class TestCreateYamlSettings:
         OverwriteSettings = type(
             "OverwriteSettings",
             (Settings,),
-            dict(__env_yaml_settings_files__=final_files),
+            dict(__env_yaml_files__=final_files),
         )
         yaml_settings = CreateYamlSettings(OverwriteSettings)
 

--- a/yaml_settings_pydantic/__init__.py
+++ b/yaml_settings_pydantic/__init__.py
@@ -46,7 +46,7 @@ class CreateYamlSettings(PydanticBaseSettingsSource):
         self,
         settings_cls: Type,
     ):
-        filepaths: Sequence[str] | None = getattr(
+        filepaths: str | Sequence[str] | None = getattr(
             settings_cls,
             s := "__env_yaml_settings_files__",
             None,
@@ -57,13 +57,13 @@ class CreateYamlSettings(PydanticBaseSettingsSource):
             False,
         )
 
-        if filepaths is None or not (n := len(filepaths)):
+        if isinstance(filepaths, str):
+            filepaths = [filepaths]
+        if filepaths is None or not len(filepaths):
             msg = f"`{s}` is required."
             raise ValueError(msg)
 
         logger.debug("Constructing `CreateYamlSettings`.")
-        if n == 0:
-            raise ValueError("Atleast one file is required.")
 
         self.loaded = None
         self.reload = reload

--- a/yaml_settings_pydantic/__init__.py
+++ b/yaml_settings_pydantic/__init__.py
@@ -68,7 +68,7 @@ class CreateYamlSettings(PydanticBaseSettingsSource):
         _msg_found = _msg.replace("Looking for", "Found")
 
         # Bc naming
-        cls_field = f"__env_yaml_settings_{field}__"
+        cls_field = f"__env_yaml_{field}__"
         config_field = f"yaml_{field}"
 
         logger.debug(_msg, field, config_field, "settings_cls")
@@ -180,15 +180,15 @@ class BaseYamlSettings(BaseSettings):
     Dunder settings will be passed to `CreateYamlSettings`s constuctor.
 
     :attr model_config: Secondary source for dunder (`__`) prefixed values.
-    :attr __env_yaml_settings_reload__: Reload files when constructor
-    :attr __env_yaml_settings_files__: All of the files to load to populate
+    :attr __env_yaml_reload__: Reload files when constructor
+    :attr __env_yaml_files__: All of the files to load to populate
         settings fields (in order of ascending importance).
     """
 
     model_config: ClassVar[YamlSettingsConfigDict]
 
-    __env_yaml_settings_files__: ClassVar[Optional[Sequence[str]]]
-    __env_yaml_settings_reload__: ClassVar[Optional[bool]]
+    __env_yaml_files__: ClassVar[Optional[Sequence[str]]]
+    __env_yaml_reload__: ClassVar[Optional[bool]]
 
     @classmethod
     def settings_customise_sources(


### PR DESCRIPTION
Fixed up ugly naming before release of v2. In particular

- `__env_yaml_settings_files__` -> `__yaml_files__`.
- `__env_yaml_settings_reload` -> `__yaml_reload__`.
- `filepaths` -> `files`.

Added `YamlSettingsConfigDict` extend `SettingsConfigDict` and provide type hints. This can be used in place of __yaml_settings__.