### PR TITLE
Fix/py typed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build
 .mypy_cache
 .jedi
 env
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,7 @@ push            = false
 
 
 [tool.setuptools_scm]
+
+
+[tool.setuptools.package-data]
+"yaml_settings_pydantic" = ["py.typed"]

--- a/yaml_settings_pydantic/__init__.py
+++ b/yaml_settings_pydantic/__init__.py
@@ -49,7 +49,7 @@ T = TypeVar("T")
 
 
 class YamlFileConfigDict(TypedDict):
-    subpath: Optional[str]
+    subpath: NotRequired[Optional[str]]
     required: bool
 
 


### PR DESCRIPTION
# chore(add-mypy-support): Added Mypy Sypport

Added py.typed.
Fixed subtle type hint issue. Subpath is ``NotRequired``.